### PR TITLE
Add workflow for converting patch CSV

### DIFF
--- a/.github/workflows/convert_csv.yml
+++ b/.github/workflows/convert_csv.yml
@@ -2,31 +2,23 @@ name: Convert CSV to Capture
 
 on:
   push:
-    paths:
-      - 'convert-cvs/**/*.csv'
-      - 'convert_csvs.py'
-      - '.github/workflows/convert_csv.yml'
-  pull_request:
-    paths:
-      - 'convert-cvs/**/*.csv'
-      - 'convert_csvs.py'
-      - '.github/workflows/convert_csv.yml'
+    branches: [main]
 
 jobs:
   convert:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-      - name: Run converter
-        run: python convert_csvs.py
-      - name: Upload results
-        uses: actions/upload-artifact@v3
+          python-version: 3.11
+      - name: Install dependencies
+        run: pip install pandas
+      - name: Run conversion script
+        run: python convert.py
+      - name: Upload converted file
+        uses: actions/upload-artifact@v4
         with:
-          name: converted-csvs
-          path: converted-csvs
-          if-no-files-found: ignore
+          name: converted-csv
+          path: capture_patch_export.csv

--- a/convert.py
+++ b/convert.py
@@ -1,0 +1,79 @@
+import csv
+import uuid
+import re
+
+INPUT_FILE = 'patch_klein.csv'
+OUTPUT_FILE = 'capture_patch_export.csv'
+
+OUTPUT_HEADER = [
+    "Fixture", "Optics", "Wattage", "Unit", "Circuit", "Channel", "Groups", "Patch",
+    "DMX Mode", "DMX Channels", "Position X", "Position Y", "Position Z",
+    "Focus Pan", "Focus Tilt", "Invert Pan", "Pan Start Limit", "Pan End Limit",
+    "Invert Tilt", "Tilt Start Limit", "Tilt End Limit", "Identifier", "External Identifier"
+]
+
+ADDRESS_RE = re.compile(r"^\s*(\d+)\s*/\s*(\d+)\s*$")
+
+
+def convert():
+    with open(INPUT_FILE, encoding='latin1', newline='') as f:
+        reader = csv.reader(f)
+        next(reader, None)  # skip START_CHANNELS
+        header = next(reader)
+        indices = {name: idx for idx, name in enumerate(header)}
+
+        rows = list(reader)
+
+    with open(OUTPUT_FILE, 'w', encoding='utf-8', newline='') as f_out:
+        writer = csv.writer(f_out)
+        writer.writerow(OUTPUT_HEADER)
+
+        for row in rows:
+            if not row:
+                continue
+            tag = row[0]
+            if tag in ('END_CHANNELS', 'START_FIXTURES'):
+                break
+
+            address_field = row[indices['ADDRESS']]
+            m = ADDRESS_RE.match(address_field)
+            if not m:
+                continue
+            patch = f"{m.group(1)}.{m.group(2)}"
+
+            fixture = f"{row[indices['MANUFACTURER']].strip()} {row[indices['FIXTURE_TYPE']].strip()}".strip()
+            channel = row[indices['CHANNEL']].strip()
+            pos_x = f"{row[indices['LOCATION_X']]}m"
+            pos_y = f"{row[indices['LOCATION_Z']]}m"
+            pos_z = f"{row[indices['LOCATION_Y']]}m"
+            identifier = str(uuid.uuid4())
+
+            out_row = [
+                fixture,
+                'N/A',     # Optics
+                'N/A',     # Wattage
+                '',        # Unit
+                '',        # Circuit
+                channel,
+                '',        # Groups
+                patch,
+                'Standard',  # DMX Mode
+                1,           # DMX Channels
+                pos_x,
+                pos_y,
+                pos_z,
+                '0°',     # Focus Pan
+                '0°',     # Focus Tilt
+                'No',     # Invert Pan
+                '0°',     # Pan Start Limit
+                '0°',     # Pan End Limit
+                'No',     # Invert Tilt
+                '0°',     # Tilt Start Limit
+                '0°',     # Tilt End Limit
+                identifier,
+                'N/A'      # External Identifier
+            ]
+            writer.writerow(out_row)
+
+if __name__ == '__main__':
+    convert()


### PR DESCRIPTION
## Summary
- add `convert.py` for converting `patch_klein.csv` to `capture_patch_export.csv`
- update `convert_csv.yml` workflow to run on `main` push, use updated action versions, and upload converted CSV

## Testing
- `python3 convert.py`
- `pip install pandas`


------
https://chatgpt.com/codex/tasks/task_e_68504f398f70833198ce6bd36b479cf8