### PR TITLE
Fix workflow trigger and README notes

### DIFF
--- a/.github/workflows/convert_csv.yml
+++ b/.github/workflows/convert_csv.yml
@@ -2,7 +2,7 @@ name: Convert CSV to Capture
 
 on:
   push:
-    branches: [main]
+  pull_request:
 
 jobs:
   convert:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Die erzeugten Dateien werden im Ordner `converted-csvs` abgelegt.
 Der Dateiname richtet sich nach der Eingabedatei und endet auf
 `_capture_patch_export.csv`.
 
+### Beispiel-Dateien
+
+Im Repository liegen zwei Referenzdateien:
+`example-eos.cvs` als Eingabebeispiel und `example-capture.cvs` als
+entsprechende Ausgabe. Bitte weder löschen noch sperren, damit die
+Beispiele erhalten bleiben.
+
 
 ## Automatische Konvertierung mit GitHub Actions
 


### PR DESCRIPTION
## Summary
- trigger GitHub Actions on every push and pull request
- document that `example-eos.cvs` and `example-capture.cvs` should remain in the repo

## Testing
- `python3 convert_csvs.py`
- `ls converted-csvs`

------
https://chatgpt.com/codex/tasks/task_e_68505afaf5fc8331a567ea275d14d97f